### PR TITLE
This fix allows LibUSB to go to another interface before bailing 

### DIFF
--- a/libusb/os/windows_winusb.c
+++ b/libusb/os/windows_winusb.c
@@ -4670,7 +4670,7 @@ static int composite_submit_control_transfer(int sub_api, struct usbi_transfer *
 				usbi_dbg(TRANSFER_CTX(transfer), "using interface %d", iface);
 				r = priv->usb_interface[iface].apib->submit_control_transfer(priv->usb_interface[iface].sub_api, itransfer);
 				// If not supported on this API, it may be supported on another, so don't give up yet!!
-				if (r == LIBUSB_ERROR_NOT_SUPPORTED)
+				if (r == LIBUSB_ERROR_NOT_SUPPORTED || r == LIBUSB_ERROR_NOT_FOUND)
 					continue;
 				return r;
 			}


### PR DESCRIPTION
If a winUSB happens to be connected by another application, and it's before HID interfaces it will return LIBUSB_ERROR_NOT_FOUND. 
This happens because when you try to get the serial number from the descriptor, the composite device doesn't need to have an interface and will just try to loop through each of the interfaces and try to get the serial number. 